### PR TITLE
fix: resolve infinite loader on login by parsing profile check response

### DIFF
--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -193,7 +193,12 @@ export const useProfileStore = create<ProfileStore>()(
           try {
             const response = await checkProfile(token)
             if (response.status >= 200 && response.status < 300) {
-              set({ loading: false, success: true, hasProfile: response.data })
+              const isProfileComplete = response.status === 200
+              set({
+                loading: false,
+                success: true,
+                hasProfile: isProfileComplete,
+              })
               return response
             } else {
               console.error(`Unexpected status: ${response.status}`)


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/869cu63fh)

**What has been done:**
- [X] Added API response compatibility:  
Updated `checkProfile` action in `src/zustand/store.ts`.  
`hasProfile` state is now derived by evaluating HTTP response status (`response.status === 200`)

**How to test:**
1. Log in with an existing user who has a completed profile — you should be successfully redirected to the main app (`/friends`).
2. Log in with a new user (or a user with an incomplete profile that receives `204 No Content`) — you should be successfully redirected to `/fill-profile`.

**Checklist:**
- [X] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier
