### PR TITLE
Wfw 869ctwmnc refactor CommonModal

### DIFF
--- a/src/common/components/CommonModal.tsx
+++ b/src/common/components/CommonModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Box, Modal, Icon } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import { makeStyles } from 'tss-react/mui'
@@ -7,23 +7,26 @@ import theme from '../../styles/createTheme'
 type CommonModalProps = {
   children: ReactNode
   isOpened: boolean
-  modalTitle: string
-  modalDescription: string
+  modalDescriptionID?: string
   onClose: () => void
   height?: 240 | 320 | 370 | 470 | 605
   width?: 600
   contentOverflow?: 'auto' | 'visible' | 'hidden'
-}
+} & (
+  | { ariaLabel: string; modalTitleID?: never }
+  | { ariaLabel?: never; modalTitleID: string }
+)
 
 export const CommonModal = ({
   children,
   isOpened,
-  modalTitle,
-  modalDescription,
+  modalTitleID,
+  modalDescriptionID,
   onClose,
   height,
   width,
   contentOverflow = 'auto',
+  ariaLabel,
 }: CommonModalProps) => {
   const { classes } = useStyles()
 
@@ -31,8 +34,9 @@ export const CommonModal = ({
     <Modal
       className={classes.modal}
       open={isOpened}
-      aria-labelledby={modalTitle}
-      aria-describedby={modalDescription}
+      aria-label={ariaLabel}
+      aria-labelledby={modalTitleID}
+      aria-describedby={modalDescriptionID}
       onClose={onClose}
     >
       <Box
@@ -97,7 +101,7 @@ const useStyles = makeStyles()(() => ({
     right: 15,
     top: 15,
     minWidth: 0,
-    '&: hover': {
+    '&:hover': {
       transform: 'scale(105%)',
       cursor: 'pointer',
     },

--- a/src/common/components/CommonModal.tsx
+++ b/src/common/components/CommonModal.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { Box, Modal, Icon } from '@mui/material'
+import { Box, Modal } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import { makeStyles } from 'tss-react/mui'
 import theme from '../../styles/createTheme'
@@ -9,8 +9,8 @@ type CommonModalProps = {
   isOpened: boolean
   modalDescriptionID?: string
   onClose: () => void
-  height?: 240 | 320 | 370 | 470 | 605
-  width?: 600
+  height?: number | 'auto'
+  width?: number
   contentOverflow?: 'auto' | 'visible' | 'hidden'
 } & (
   | { ariaLabel: string; modalTitleID?: never }
@@ -23,8 +23,8 @@ export const CommonModal = ({
   modalTitleID,
   modalDescriptionID,
   onClose,
-  height,
-  width,
+  height = 'auto',
+  width = 370,
   contentOverflow = 'auto',
   ariaLabel,
 }: CommonModalProps) => {
@@ -39,20 +39,14 @@ export const CommonModal = ({
       aria-describedby={modalDescriptionID}
       onClose={onClose}
     >
-      <Box
-        className={classes.wrapper}
-        sx={{ height: height ? height : 655, width: width ? width : 370 }}
-      >
+      <Box className={classes.wrapper} sx={{ height, width }}>
         <IconButton
-          disableRipple={true}
-          disableFocusRipple={true}
+          disableRipple
           aria-label="close modal"
           className={classes.closeButton}
           onClick={onClose}
         >
-          <Icon>
-            <img src="/img/icon-close-modal.svg" alt="Close" />
-          </Icon>
+          <img src="/img/icon-close-modal.svg" alt="Close" />
         </IconButton>
         <Box
           className={classes.wrapperContent}

--- a/src/components/chat/DeleteContactModal.tsx
+++ b/src/components/chat/DeleteContactModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useId } from 'react'
 import { Box, Button, Typography } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { CommonModal } from 'common/components/CommonModal'
@@ -16,13 +16,13 @@ export const DeleteContactModal = ({
   onConfirm,
 }: DeleteContactModalProps) => {
   const { classes } = useStyles()
+  const titleId = useId()
 
   return (
     <CommonModal
       isOpened={isOpen}
       onClose={onClose}
-      modalTitle=""
-      modalDescription=""
+      modalTitleID={titleId}
       height={320}
     >
       <Box className={classes.modalContainer}>
@@ -32,7 +32,7 @@ export const DeleteContactModal = ({
           className={classes.imgAlert}
         />
         <Box className={classes.info}>
-          <Typography variant="h1" className={classes.title}>
+          <Typography variant="h1" id={titleId} className={classes.title}>
             Delete User
           </Typography>
         </Box>

--- a/src/components/deleteUser/DeleteUserDialog.tsx
+++ b/src/components/deleteUser/DeleteUserDialog.tsx
@@ -28,8 +28,7 @@ const DeleteUserDialog = forwardRef((props: DeleteUserDialogProps, ref) => {
   return (
     <CommonModal
       isOpened={isModalVisible}
-      modalTitle={'Delete User'}
-      modalDescription={'Confirm to delete user.'}
+      ariaLabel="Delete User"
       onClose={handleClose}
       height={320}
     >

--- a/src/components/findMatch/Match.tsx
+++ b/src/components/findMatch/Match.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { Box, Avatar, Typography, Button } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import theme from '../../styles/createTheme'
@@ -19,6 +20,8 @@ export function Match({
   currentUserAvatar = '/img/firstProfile/female.svg',
 }: MatchProps) {
   const { classes } = useStyles()
+  const titleId = useId()
+  const descriptionId = useId()
   const startChatWith = useStartChatWith()
 
   function handleStartChat() {
@@ -31,8 +34,8 @@ export function Match({
     <CommonModal
       isOpened={!!matchedUser}
       onClose={onClose}
-      modalTitle={'modal-modal-title'}
-      modalDescription={'modal-modal-description'}
+      modalTitleID={titleId}
+      modalDescriptionID={descriptionId}
       height={605}
     >
       <Box className={classes.matchContainer}>
@@ -44,10 +47,10 @@ export function Match({
           />
         </Box>
         <Box className={classes.info}>
-          <Typography variant="h1" className={classes.title}>
+          <Typography variant="h1" id={titleId} className={classes.title}>
             Wow! It’s a Match!
           </Typography>
-          <Typography className={classes.subTitle}>
+          <Typography id={descriptionId} className={classes.subTitle}>
             Hurry up to say hello to your new friend!
           </Typography>
         </Box>

--- a/src/components/myAccount/ChangeProfileDialog.tsx
+++ b/src/components/myAccount/ChangeProfileDialog.tsx
@@ -49,8 +49,7 @@ const ChangeProfileDialog = forwardRef(
     return (
       <CommonModal
         isOpened={isModalVisible}
-        modalTitle={'Edit Profile'}
-        modalDescription={'Update your profile photos and preferences.'}
+        ariaLabel="Edit Profile"
         onClose={handleClose}
         width={600}
       >

--- a/src/components/myAccount/ChangeProfileDialog.tsx
+++ b/src/components/myAccount/ChangeProfileDialog.tsx
@@ -52,6 +52,7 @@ const ChangeProfileDialog = forwardRef(
         ariaLabel="Edit Profile"
         onClose={handleClose}
         width={600}
+        height={655}
       >
         <UploadPhotos />
         <Box className={classes.titleContainer}>

--- a/src/components/report/ReportDialog.tsx
+++ b/src/components/report/ReportDialog.tsx
@@ -50,8 +50,7 @@ const ReportDialog = forwardRef((props: ReportDialogProps, ref) => {
   return (
     <CommonModal
       isOpened={isModalVisible}
-      modalTitle={'Report User'}
-      modalDescription={'Choose an action to report or block the user.'}
+      ariaLabel="Report User"
       onClose={handleClose}
       height={modalHeight}
     >

--- a/src/components/securityDialog/SecurityDialog.tsx
+++ b/src/components/securityDialog/SecurityDialog.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useState,
   useEffect,
   forwardRef,
@@ -50,8 +50,7 @@ const SecurityDialog = forwardRef((props: ReportDialogProps, ref) => {
   return (
     <CommonModal
       isOpened={isModalVisible}
-      modalTitle={'Report User'}
-      modalDescription={'Choose an action to report or block the user.'}
+      ariaLabel="Manage User"
       onClose={handleClose}
       height={modalHeight}
     >

--- a/src/pages/NoMoreMatchesDialog.tsx
+++ b/src/pages/NoMoreMatchesDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, Ref, useImperativeHandle } from 'react'
+import { useState, forwardRef, Ref, useImperativeHandle, useId } from 'react'
 import { Box, Button, Typography } from '@mui/material'
 import { CommonModal } from 'common/components/CommonModal'
 import { makeStyles } from 'tss-react/mui'
@@ -15,6 +15,8 @@ interface NoMoreMatchesDialogProps {
 const NoMoreMatchesDialog = forwardRef(
   (props: NoMoreMatchesDialogProps, ref) => {
     const { classes } = useStyles()
+    const titleId = useId()
+    const descriptionId = useId()
     const [isModalVisible, setIsModalVisible] = useState(false)
 
     const handleOpenNoMoreMatchesDialog = () => {
@@ -32,17 +34,21 @@ const NoMoreMatchesDialog = forwardRef(
     return (
       <CommonModal
         isOpened={isModalVisible}
-        modalTitle={props.title}
-        modalDescription={props.description || ''}
+        modalTitleID={titleId}
+        modalDescriptionID={descriptionId}
         onClose={handleClose}
         height={605}
         contentOverflow="visible"
       >
         <Box>
-          <Typography variant="h2" className={classes.title}>
+          <Typography variant="h2" id={titleId} className={classes.title}>
             {props.title}
           </Typography>
-          <Typography variant="body2" className={classes.description}>
+          <Typography
+            variant="body2"
+            id={descriptionId}
+            className={classes.description}
+          >
             {props.description}
           </Typography>
           <Box className={classes.slidersWrapper}>


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/869ctwmnc)

**What has been done:**
- [X] Fixed incorrect usage of `aria-labelledby`, `aria-describedby`. These attributes require element IDs, not text strings. Replaced `modalTitle`, `modalDescription` props with a union type: 
either `ariaLabel` (direct text) or `modalTitleID` (element ID) must be provided; 
`modalDescriptionID` is optional
- [X] set default `height` to `auto` in CommonModal

**Blockers / Dependencies:**
none

**How to test:**
1. Open each modal and verify it renders correctly: Delete Contact, Delete User, Security Dialog (block/delete flow), Report Dialog (report flow), Match, No More Matches, Change Profile
2. Verify modals renders correctly with height and width, content should be visible and scrollable

**Checklist:**
- [-] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier

**Screenshots**:
none