### PR TITLE
fix: correct avatar type, pass avatarSrc prop on Swipes page

### DIFF
--- a/src/common/components/UserProfileLink.tsx
+++ b/src/common/components/UserProfileLink.tsx
@@ -5,11 +5,7 @@ import { useProfileStore } from 'zustand/store'
 
 export function UserProfileLink() {
   const { data: profile, loading } = useProfileStore()
-  const avatar = profile?.photos?.[0]
-  const avatarSrc =
-    typeof avatar === 'string'
-      ? avatar
-      : avatar?.url ?? '/img/placeholders/girl-big.svg'
+  const avatarSrc = profile?.photos?.[0] ?? '/img/placeholders/girl-big.svg'
   const { classes } = useStyles()
 
   return (

--- a/src/components/firstProfile/uploadPhotos/useRestorePhotos.ts
+++ b/src/components/firstProfile/uploadPhotos/useRestorePhotos.ts
@@ -11,7 +11,7 @@ export function useRestorePhotos() {
     restoredRef.current = true
     const restored: UserPicsType[] = data.photos.map((photo, i) => ({
       id: `url-${i}`,
-      url: typeof photo === 'string' ? photo : photo.url,
+      url: photo,
       blobFile: null,
     }))
     setTempPhotos(restored)

--- a/src/components/myAccount/MyProfile.tsx
+++ b/src/components/myAccount/MyProfile.tsx
@@ -41,11 +41,7 @@ const MyProfile: React.FC = () => {
         <Box className={classes.person}>
           <Avatar
             className={classes.avatar}
-            src={
-              typeof profile?.photos?.[0] === 'string'
-                ? profile?.photos?.[0]
-                : profile?.photos?.[0]?.url ?? '/img/placeholders/girl-big.svg'
-            }
+            src={profile?.photos?.[0] ?? '/img/placeholders/girl-big.svg'}
           />
           <Typography variant="h1" className={classes.name}>
             {loading ? 'Loading...' : profile?.name},{' '}

--- a/src/components/myAccount/MyProfile.tsx
+++ b/src/components/myAccount/MyProfile.tsx
@@ -25,9 +25,7 @@ const MyProfile: React.FC = () => {
 
   useEffect(() => {
     if (profile?.photos?.length) {
-      setUserPhotos(
-        profile.photos.map((photo) => ({ src: photo as unknown as string }))
-      )
+      setUserPhotos(profile.photos.map((photo) => ({ src: photo })))
     }
   }, [profile?.photos])
 

--- a/src/components/swipes/Swipes.tsx
+++ b/src/components/swipes/Swipes.tsx
@@ -31,6 +31,7 @@ const Swipes = () => {
   } = usePotentialFriendsStore()
 
   const { data: profile } = useProfileStore()
+  const currentUserAvatarSrc = profile?.photos?.[0]
 
   // Fetch potential friends when profile is loaded
   useEffect(() => {
@@ -119,7 +120,11 @@ const Swipes = () => {
             <UserProfileButton skip={onSkip} beFriend={onBeFriend} />
           </>
         )}
-        <Match matchedUser={matchedUser} onClose={handleModalClose} />
+        <Match
+          matchedUser={matchedUser}
+          currentUserAvatar={currentUserAvatarSrc}
+          onClose={handleModalClose}
+        />
       </Box>
       <NoMoreMatchesDialog
         ref={NoMoreMatchesDialogRef}

--- a/src/pages/NearMePage.tsx
+++ b/src/pages/NearMePage.tsx
@@ -12,11 +12,7 @@ import { useProfileStore } from 'zustand/store'
 
 export default function NearMePage() {
   const { data: profile } = useProfileStore()
-  const currentUserAvatar = profile?.photos?.[0]
-  const currentUserAvatarSrc =
-    typeof currentUserAvatar === 'string'
-      ? currentUserAvatar
-      : currentUserAvatar?.url ?? ''
+  const currentUserAvatarSrc = profile?.photos?.[0]
 
   const { isOpen, snackbarInfo, showSnackbar, handleCloseSnackbar } =
     useSnackbar()

--- a/src/pages/WhoLikedMePage.tsx
+++ b/src/pages/WhoLikedMePage.tsx
@@ -12,11 +12,7 @@ import { useProfileStore } from 'zustand/store'
 
 export default function WhoLikedMePage() {
   const { data: profile } = useProfileStore()
-  const currentUserAvatar = profile?.photos?.[0]
-  const currentUserAvatarSrc =
-    typeof currentUserAvatar === 'string'
-      ? currentUserAvatar
-      : currentUserAvatar?.url ?? ''
+  const currentUserAvatarSrc = profile?.photos?.[0]
 
   const { isOpen, snackbarInfo, showSnackbar, handleCloseSnackbar } =
     useSnackbar()

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -26,7 +26,7 @@ interface Profile {
   name: string
   dateOfBirth: string
   location: Location
-  photos: (string | { url: string })[]
+  photos: string[]
   gender: string
   reasons: string[]
   friendsAgeMin?: number
@@ -322,7 +322,7 @@ export const useProfileStore = create<ProfileStore>()(
               data: {
                 ...state.data,
                 photos: state.data.photos.map((p) =>
-                  (typeof p === 'string' ? p : p.url) === oldUrl ? newUrl : p
+                  p === oldUrl ? newUrl : p
                 ),
               },
             }


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/869dex41a)

**What has been done:**
- [X] Fixed missing `currentUserAvatarSrc` declaration in `Swipes.tsx` and pass to Match popup
- [X] Narrowed `Profile.photos` type in `useProfileStore` from `(string | { url: string })[]` to `string[]` (the object branch was dead code, server always returns string URLs)

**Blockers / Dependencies:**
none

**How to test:**
1. Open `Swipes` page and trigger Match popup. 
2. Verify your avatar appears correctly in the match popup

**Checklist:**
- [ ] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier

**Screenshots**:

| **before**  | **after** | 
|:---------------------:|:-----------------------:|
| <a href="https://github.com/user-attachments/assets/258caa47-1b69-463d-bcdc-3162be7fc82a"><img src="https://github.com/user-attachments/assets/258caa47-1b69-463d-bcdc-3162be7fc82a" width="250"></a> | <a href="https://github.com/user-attachments/assets/bd8e5efb-d943-4369-94aa-1795a87a315b"><img src="https://github.com/user-attachments/assets/bd8e5efb-d943-4369-94aa-1795a87a315b" width="250"></a> | 