### PR TITLE
Wfw 869dge3u7 unify photos response format

### DIFF
--- a/src/common/components/UserProfileLink.tsx
+++ b/src/common/components/UserProfileLink.tsx
@@ -2,10 +2,11 @@ import { Link } from 'react-router-dom'
 import { Avatar, Button, Typography } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { useProfileStore } from 'zustand/store'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 export function UserProfileLink() {
   const { data: profile, loading } = useProfileStore()
-  const avatarSrc = profile?.photos?.[0] ?? '/img/placeholders/girl-big.svg'
+  const avatarSrc = profile?.photos?.[0] ?? DEFAULT_PROFILE_PHOTO
   const { classes } = useStyles()
 
   return (

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ chat }: ChatHeaderProps) {
       id: chat.id,
       name: chat.name,
       age: chat.age,
-      photos: [{ src: chat.avatar }],
+      photos: [chat.avatar],
     }
 
     setSelectedProfile(profile)

--- a/src/components/myAccount/MyProfile.tsx
+++ b/src/components/myAccount/MyProfile.tsx
@@ -7,6 +7,7 @@ import PrimaryButton from '../../common/components/PrimaryButton'
 import ChangeProfileDialog from './ChangeProfileDialog'
 import { useProfileStore } from '../../zustand/store'
 import { getAge } from '../../utils/getAge'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 const MyProfile: React.FC = () => {
   const { classes } = useStyles()
@@ -15,13 +16,7 @@ const MyProfile: React.FC = () => {
   }>(null)
   const { data: profile, loading } = useProfileStore()
 
-  const defaultPhotos = [
-    '/img/placeholders/girl-big.svg',
-    '/img/placeholders/girl-big.svg',
-    '/img/placeholders/girl-big.svg',
-  ]
-
-  const [userPhotos, setUserPhotos] = useState(defaultPhotos)
+  const [userPhotos, setUserPhotos] = useState([DEFAULT_PROFILE_PHOTO])
 
   useEffect(() => {
     if (profile?.photos?.length) {
@@ -39,7 +34,7 @@ const MyProfile: React.FC = () => {
         <Box className={classes.person}>
           <Avatar
             className={classes.avatar}
-            src={profile?.photos?.[0] ?? '/img/placeholders/girl-big.svg'}
+            src={profile?.photos?.[0] ?? DEFAULT_PROFILE_PHOTO}
           />
           <Typography variant="h1" className={classes.name}>
             {loading ? 'Loading...' : profile?.name},{' '}

--- a/src/components/myAccount/MyProfile.tsx
+++ b/src/components/myAccount/MyProfile.tsx
@@ -16,16 +16,16 @@ const MyProfile: React.FC = () => {
   const { data: profile, loading } = useProfileStore()
 
   const defaultPhotos = [
-    { src: '/img/placeholders/girl-big.svg' },
-    { src: '/img/placeholders/girl-big.svg' },
-    { src: '/img/placeholders/girl-big.svg' },
+    '/img/placeholders/girl-big.svg',
+    '/img/placeholders/girl-big.svg',
+    '/img/placeholders/girl-big.svg',
   ]
 
   const [userPhotos, setUserPhotos] = useState(defaultPhotos)
 
   useEffect(() => {
     if (profile?.photos?.length) {
-      setUserPhotos(profile.photos.map((photo) => ({ src: photo })))
+      setUserPhotos(profile.photos)
     }
   }, [profile?.photos])
 

--- a/src/components/swipes/Swipes.tsx
+++ b/src/components/swipes/Swipes.tsx
@@ -74,7 +74,7 @@ const Swipes = () => {
     if (currentPotentialFriend.likedMe) {
       setMatchedUser({
         id: currentPotentialFriend.id,
-        avatar: currentPotentialFriend.photos[0].src,
+        avatar: currentPotentialFriend.photos[0],
       })
     }
     handleLike(currentPotentialFriend.id)

--- a/src/components/tabsMessagesFriends/Friends.tsx
+++ b/src/components/tabsMessagesFriends/Friends.tsx
@@ -11,6 +11,7 @@ import { NoNewMatchesOrMessages } from './NoNewMatchesOrMessages'
 import { useMatchesStore } from 'zustand/friendsStore'
 import { useUserProfileStore } from 'zustand/userProfileStore'
 import { mapProfileToData } from 'utils/mapProfileToData'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 interface FriendsProps {
   onClick: (userProfileData: UserProfileData) => void
@@ -23,7 +24,7 @@ export function Friends({ onClick }: FriendsProps) {
   const [selectedFriendId, setSelectedFriendId] = useState<string | null>(null)
   const [loading, setLoading] = useState<string | null>(null)
 
-  const defaultPhoto = '/img/placeholders/girl-big.svg'
+  const defaultPhoto = DEFAULT_PROFILE_PHOTO
 
   const handleClick = async (friend: FriendsMatch) => {
     setSelectedFriendId(friend.id)

--- a/src/components/tabsMessagesFriends/Friends.tsx
+++ b/src/components/tabsMessagesFriends/Friends.tsx
@@ -33,7 +33,7 @@ export function Friends({ onClick }: FriendsProps) {
       id: friend.id,
       name: friend.name,
       age: friend.age.toString(),
-      photos: [{ src: friend.photo }],
+      photos: [friend.photo],
     }
 
     onClick(mapProfileToData(null, selectedFriend))

--- a/src/components/userProfile/PhotoCarousel.tsx
+++ b/src/components/userProfile/PhotoCarousel.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
 import Carousel from 'react-material-ui-carousel'
 import UserPic from './UserPic'
-import { UserPhoto } from 'types/UserProfileData'
+import { ProfilePhoto } from 'types/UserProfileData'
 import { ArrowBackIosNew, ArrowForwardIos } from '@mui/icons-material'
 import { Box } from '@mui/material'
 import { PhotoModal } from 'components/firstProfile/uploadPhotos/PhotoModal'
 
 interface PhotoCarouselProps {
-  items: UserPhoto[]
+  items: ProfilePhoto[]
   className?: string
 }
 
@@ -103,14 +103,14 @@ export const PhotoCarousel: React.FC<PhotoCarouselProps> = ({
             height: { xs: 420, sm: 535 },
           }}
         >
-          {items.length > 0 && items[0].src !== defaultPhoto ? (
-            items.map((item: UserPhoto) => (
+          {items.length > 0 && items[0] !== defaultPhoto ? (
+            items.map((item: ProfilePhoto) => (
               <div
-                key={item.src}
-                onClick={() => handleImageClick(item.src)}
+                key={item}
+                onClick={() => handleImageClick(item)}
                 style={{ cursor: 'pointer' }}
               >
-                <UserPic src={item.src} />
+                <UserPic src={item} />
               </div>
             ))
           ) : (

--- a/src/components/userProfile/PhotoCarousel.tsx
+++ b/src/components/userProfile/PhotoCarousel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import Carousel from 'react-material-ui-carousel'
 import UserPic from './UserPic'
 import { ProfilePhoto } from 'types/UserProfileData'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 import { ArrowBackIosNew, ArrowForwardIos } from '@mui/icons-material'
 import { Box } from '@mui/material'
 import { PhotoModal } from 'components/firstProfile/uploadPhotos/PhotoModal'
@@ -18,7 +19,7 @@ export const PhotoCarousel: React.FC<PhotoCarouselProps> = ({
   const [modalOpen, setModalOpen] = useState(false)
   const [selectedImage, setSelectedImage] = useState('')
 
-  const defaultPhoto = '/img/placeholders/girl-big.svg'
+  const defaultPhoto = DEFAULT_PROFILE_PHOTO
 
   const handleImageClick = (src: string) => {
     setSelectedImage(src)

--- a/src/components/userProfile/UserProfile.tsx
+++ b/src/components/userProfile/UserProfile.tsx
@@ -14,6 +14,7 @@ import { PhotoCarousel } from './PhotoCarousel'
 import { UserProfileData } from '../../types/UserProfileData'
 import LikeDispay from './LikedDisplay'
 import ReportDialog from 'components/report/ReportDialog'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 interface UserProfileProps {
   user: UserProfileData
@@ -57,7 +58,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
             items={
               user.photos && user.photos.length > 0
                 ? user.photos
-                : ['/img/placeholders/girl-big.svg']
+                : [DEFAULT_PROFILE_PHOTO]
             }
           />
           <Box className={classes.gradientOverlay} />

--- a/src/components/userProfile/UserProfile.tsx
+++ b/src/components/userProfile/UserProfile.tsx
@@ -57,7 +57,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
             items={
               user.photos && user.photos.length > 0
                 ? user.photos
-                : [{ src: '/img/placeholders/girl-big.svg' }]
+                : ['/img/placeholders/girl-big.svg']
             }
           />
           <Box className={classes.gradientOverlay} />

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,5 +1,7 @@
 export const MAX_PROFILE_PHOTOS = 6
 export const MAX_PHOTO_SIZE_BYTES = 5 * 1024 * 1024
 
+export const DEFAULT_PROFILE_PHOTO = '/img/placeholders/girl-big.svg'
+
 export const AUTH_STORAGE_KEY = 'auth-storage'
 export const AUTH0_STORAGE_PREFIX = '@@auth0spajs@@'

--- a/src/types/UserProfileData.ts
+++ b/src/types/UserProfileData.ts
@@ -1,14 +1,14 @@
 import { UserPreferences } from './FirstProfile'
 
-export interface UserPhoto {
-  src: string
-}
+// A profile photo is just its URL. Aliased so that, if a photo ever needs
+// extra fields (id, order…), only this line changes
+export type ProfilePhoto = string
 
 export interface UserProfileData {
   id: string
   name: string
   age: string
-  photos: UserPhoto[]
+  photos: ProfilePhoto[]
   city: string
   distance: string
   likedMe: boolean

--- a/src/utils/mapProfileToData.ts
+++ b/src/utils/mapProfileToData.ts
@@ -11,7 +11,7 @@ export const mapProfileToData = (
     id: profile?._id || fallback?.id || '',
     name: profile?.name || fallback?.name || '',
     age: profile?.age?.toString() || fallback?.age?.toString() || '',
-    photos: profile?.photos || fallback?.photos || [{ src: defaultPhoto }],
+    photos: profile?.photos || fallback?.photos || [defaultPhoto],
     city: profile?.city || '',
     distance: profile?.distance?.toString() || '',
     likedMe: profile?.likedMe || false,

--- a/src/utils/mapProfileToData.ts
+++ b/src/utils/mapProfileToData.ts
@@ -1,11 +1,12 @@
 import { UserProfileDataShort, UserProfileData } from 'types/UserProfileData'
 import { UserProfile } from 'zustand/userProfileStore'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 export const mapProfileToData = (
   profile: UserProfile | null,
   fallback: UserProfileDataShort | null
 ): UserProfileData => {
-  const defaultPhoto = '/img/placeholders/girl-big.svg'
+  const defaultPhoto = DEFAULT_PROFILE_PHOTO
 
   return {
     id: profile?._id || fallback?.id || '',

--- a/src/zustand/conversationsStore.ts
+++ b/src/zustand/conversationsStore.ts
@@ -133,7 +133,7 @@ export const useConversationsStore = create<ConversationsState>()(
             const userMessage: Conversation = {
               id: otherParticipantId,
               avatar:
-                profile?.photos?.[0]?.src ||
+                profile?.photos?.[0] ||
                 conversationData.participantAvatar ||
                 `/img/placeholders/girl-big.svg`,
               name:
@@ -240,7 +240,7 @@ export const useConversationsStore = create<ConversationsState>()(
                 const userMessage: Conversation = {
                   id: otherParticipantId,
                   avatar:
-                    profile?.photos?.[0]?.src ||
+                    profile?.photos?.[0] ||
                     conversationData.participantAvatar ||
                     `/img/placeholders/girl-big.svg`,
                   name:

--- a/src/zustand/conversationsStore.ts
+++ b/src/zustand/conversationsStore.ts
@@ -15,6 +15,7 @@ import {
   serverTimestamp,
 } from 'firebase/firestore'
 import { useUserProfileStore } from './userProfileStore'
+import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 
 interface ConversationsState {
   conversations: Conversation[]
@@ -135,7 +136,7 @@ export const useConversationsStore = create<ConversationsState>()(
               avatar:
                 profile?.photos?.[0] ||
                 conversationData.participantAvatar ||
-                `/img/placeholders/girl-big.svg`,
+                DEFAULT_PROFILE_PHOTO,
               name:
                 profile?.name || conversationData.participantName || `Friend`,
               age:
@@ -242,7 +243,7 @@ export const useConversationsStore = create<ConversationsState>()(
                   avatar:
                     profile?.photos?.[0] ||
                     conversationData.participantAvatar ||
-                    `/img/placeholders/girl-big.svg`,
+                    DEFAULT_PROFILE_PHOTO,
                   name:
                     profile?.name ||
                     conversationData.participantName ||

--- a/src/zustand/userProfileStore.ts
+++ b/src/zustand/userProfileStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { getUserById } from './api'
 import { useAuthStore } from './store'
+import { ProfilePhoto } from 'types/UserProfileData'
 
 // Define UserProfile interface
 export interface UserProfile {
@@ -12,9 +13,7 @@ export interface UserProfile {
   city: string
   distance: number
   likedMe: boolean
-  photos: {
-    src: string
-  }[]
+  photos: ProfilePhoto[]
   reasons: string[]
   preferences: {
     questionary: {


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/9012052932/869dge3u7)

**What has been done:**
- [X] Migrated profile photos to a unified `string[]` format (was `[{ src }]`) across all profile endpoints (`/api/profile`, `/api/profile/{userId}`, `/api/profile/search`), updating every read site and constructor
- [X] Introduced `ProfilePhoto` type alias (= `string`) as the single canonical photo type, so a future shape change touches one line instead of all consumers
- [X] Extracted the placeholder image path into a shared `DEFAULT_PROFILE_PHOTO` constant, replacing it in 7 files, and removed the redundant 3-copy default photos array in `MyProfile`

**How to test:**
1. Open My Profile — your avatar and the photo carousel render correctly; with no photos a single placeholder shows (no nav arrows/indicators over one slide)
2. Open another user's profile from Swipes / Near me / Friends — their photos display, and the "It's a match" dialog shows the correct avatar
3. Open Messages / chat — each conversation shows the friend's avatar (real photo when available, placeholder otherwise)

**Checklist:**
- [ ] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier

**Screenshots**:

| **photo1 description**  | **photo1 description** | 
|:---------------------:|:-----------------------:|:------------------:|
| <a href="https://github.com/user-attachments/assets/b1eacf9d-fcec-4148-870f-5b3026c97104"><img src="https://github.com/user-attachments/assets/b1eacf9d-fcec-4148-870f-5b3026c97104" width="250"></a> | <a href="https://github.com/user-attachments/assets/af50c3ba-69fa-4b52-bd1d-cd4095ace85a"><img src="https://github.com/user-attachments/assets/af50c3ba-69fa-4b52-bd1d-cd4095ace85a" width="250"></a> | 