### PR TITLE
perf(swipe): prevent redundant API requests on page change

### DIFF
--- a/src/components/swipes/Swipes.tsx
+++ b/src/components/swipes/Swipes.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Typography } from '@mui/material'
 import { Match } from 'components/findMatch/Match'
 import UserProfile from 'components/userProfile/UserProfile'
 import { UserProfileButton } from 'components/userProfile/UserProfileButton'
-import { useEffect, useState, useRef, useMemo } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { emptyProfile, UserProfileData } from 'types/UserProfileData'
 import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
@@ -33,9 +33,13 @@ const Swipes = () => {
   const { data: profile } = useProfileStore()
   const currentUserAvatarSrc = profile?.photos?.[0]
 
-  const friendsWithNoMyLike = useMemo(() => {
-    return potentialFriends?.filter((friend) => !friend.likedByMe)
-  }, [potentialFriends])
+  const [sessionFriends, setSessionFriends] = useState<UserProfileData[]>()
+
+  useEffect(() => {
+    if (potentialFriends && sessionFriends === undefined) {
+      setSessionFriends(potentialFriends.filter((f) => !f.likedByMe))
+    }
+  }, [potentialFriends, sessionFriends])
 
   // Fetch potential friends when profile is loaded
   useEffect(() => {
@@ -45,25 +49,25 @@ const Swipes = () => {
   }, [profile, fetchPotentialFriends])
 
   useEffect(() => {
-    if (!friendsWithNoMyLike?.length) {
+    if (!sessionFriends?.length) {
       return
     }
     setNoPotentialFriends(false)
-    setFriendsData(friendsWithNoMyLike[0])
-    setCurrentPotentialFriend(friendsWithNoMyLike[0])
-  }, [friendsWithNoMyLike])
+    setFriendsData(sessionFriends[0])
+    setCurrentPotentialFriend(sessionFriends[0])
+  }, [sessionFriends])
 
   const goToNextPotentialFriend = (currentUserProfile: UserProfileData) => {
-    if (!friendsWithNoMyLike?.length) {
+    if (!sessionFriends?.length) {
       return
     }
-    const currentIndex = friendsWithNoMyLike.findIndex(
+    const currentIndex = sessionFriends.findIndex(
       (element: UserProfileData) => element.id === currentUserProfile.id
     )
-    const lastIndex = friendsWithNoMyLike.length - 1
+    const lastIndex = sessionFriends.length - 1
     if (currentIndex < lastIndex) {
-      setFriendsData(friendsWithNoMyLike[currentIndex + 1])
-      setCurrentPotentialFriend(friendsWithNoMyLike[currentIndex + 1])
+      setFriendsData(sessionFriends[currentIndex + 1])
+      setCurrentPotentialFriend(sessionFriends[currentIndex + 1])
     } else {
       setNoPotentialFriends(true)
     }
@@ -98,7 +102,7 @@ const Swipes = () => {
   return (
     <>
       <Box>
-        {isLoading || friendsWithNoMyLike === undefined ? (
+        {isLoading || sessionFriends === undefined ? (
           <Box className={classes.mainBlock}>
             <Loader />
           </Box>

--- a/src/components/swipes/Swipes.tsx
+++ b/src/components/swipes/Swipes.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Typography } from '@mui/material'
 import { Match } from 'components/findMatch/Match'
 import UserProfile from 'components/userProfile/UserProfile'
 import { UserProfileButton } from 'components/userProfile/UserProfileButton'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useMemo } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { emptyProfile, UserProfileData } from 'types/UserProfileData'
 import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
@@ -26,40 +26,44 @@ const Swipes = () => {
     potentialFriends,
     handleLike,
     handleDislike,
-    refreshPotentialFriends,
+    fetchPotentialFriends,
     isLoading,
   } = usePotentialFriendsStore()
 
   const { data: profile } = useProfileStore()
   const currentUserAvatarSrc = profile?.photos?.[0]
 
+  const friendsWithNoMyLike = useMemo(() => {
+    return potentialFriends?.filter((friend) => !friend.likedByMe)
+  }, [potentialFriends])
+
   // Fetch potential friends when profile is loaded
   useEffect(() => {
     if (profile) {
-      refreshPotentialFriends()
+      fetchPotentialFriends()
     }
-  }, [profile, refreshPotentialFriends])
+  }, [profile, fetchPotentialFriends])
 
   useEffect(() => {
-    if (!potentialFriends?.length) {
+    if (!friendsWithNoMyLike?.length) {
       return
     }
     setNoPotentialFriends(false)
-    setFriendsData(potentialFriends[0])
-    setCurrentPotentialFriend(potentialFriends[0])
-  }, [potentialFriends])
+    setFriendsData(friendsWithNoMyLike[0])
+    setCurrentPotentialFriend(friendsWithNoMyLike[0])
+  }, [friendsWithNoMyLike])
 
   const goToNextPotentialFriend = (currentUserProfile: UserProfileData) => {
-    if (!potentialFriends?.length) {
+    if (!friendsWithNoMyLike?.length) {
       return
     }
-    const currentIndex = potentialFriends.findIndex(
+    const currentIndex = friendsWithNoMyLike.findIndex(
       (element: UserProfileData) => element.id === currentUserProfile.id
     )
-    const lastIndex = potentialFriends.length - 1
+    const lastIndex = friendsWithNoMyLike.length - 1
     if (currentIndex < lastIndex) {
-      setFriendsData(potentialFriends[currentIndex + 1])
-      setCurrentPotentialFriend(potentialFriends[currentIndex + 1])
+      setFriendsData(friendsWithNoMyLike[currentIndex + 1])
+      setCurrentPotentialFriend(friendsWithNoMyLike[currentIndex + 1])
     } else {
       setNoPotentialFriends(true)
     }
@@ -94,7 +98,7 @@ const Swipes = () => {
   return (
     <>
       <Box>
-        {isLoading || potentialFriends === undefined ? (
+        {isLoading || friendsWithNoMyLike === undefined ? (
           <Box className={classes.mainBlock}>
             <Loader />
           </Box>

--- a/src/hooks/useUserListActions.ts
+++ b/src/hooks/useUserListActions.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { AlertColor } from '@mui/material'
 import { mutate } from 'swr'
-import { addDislike, addLike } from 'actions/friendsServices'
+import { addDislike } from 'actions/friendsServices'
 import { UserMiniProfile } from 'common/types/userTypes'
 import { getNextSelectedUser } from 'helpers/getNextSelectedUser'
 import { getApiErrorMessage } from 'helpers/getApiErrorMessage'
+import { usePotentialFriendsStore } from 'zustand/friendsStore'
 
 export function useUserListActions(
   swrKey: string,
@@ -15,6 +16,8 @@ export function useUserListActions(
     id: string
     avatar: string
   } | null>(null)
+
+  const { handleLike } = usePotentialFriendsStore()
 
   const handleCloseMatch = () => setMatchedUser(null)
 
@@ -63,7 +66,7 @@ export function useUserListActions(
         showSnackbar('Friend request sent', 'success')
       }
 
-      await addLike(selectedUser.id)
+      await handleLike(selectedUser.id)
       await removeUserAndSelectNext(selectedUser.id)
     } catch (e: unknown) {
       showSnackbar(getApiErrorMessage(e) || 'Failed to add friend', 'error')

--- a/src/hooks/useUserListActions.ts
+++ b/src/hooks/useUserListActions.ts
@@ -17,8 +17,6 @@ export function useUserListActions(
     avatar: string
   } | null>(null)
 
-  const { handleLike } = usePotentialFriendsStore()
-
   const handleCloseMatch = () => setMatchedUser(null)
 
   const removeUserAndSelectNext = async (userId: string) => {
@@ -66,7 +64,7 @@ export function useUserListActions(
         showSnackbar('Friend request sent', 'success')
       }
 
-      await handleLike(selectedUser.id)
+      await usePotentialFriendsStore.getState().handleLike(selectedUser.id)
       await removeUserAndSelectNext(selectedUser.id)
     } catch (e: unknown) {
       showSnackbar(getApiErrorMessage(e) || 'Failed to add friend', 'error')

--- a/src/types/UserProfileData.ts
+++ b/src/types/UserProfileData.ts
@@ -14,6 +14,7 @@ export interface UserProfileData {
   likedMe: boolean
   reasons: string[]
   preferences?: UserPreferences
+  likedByMe?: boolean
 }
 
 export type UserProfileDataShort = Pick<

--- a/src/zustand/friendsStore.ts
+++ b/src/zustand/friendsStore.ts
@@ -187,10 +187,14 @@ export const usePotentialFriendsStore = create<PotentialFriendsStore>()(
         await get().fetchPotentialFriends()
         // todo: when we have a queue with potential friends and then change the filters, for example ageRange set to very narrow, one of potential friends is still remaining in queue and nothing happens when I push "skip" (dislike), it should disappear from the queue and the queue should become empty
       },
-      //TODO: why we have handleLike and handleDislike in the store?
-      // They don't change the state of the store, they just call the API and return status.
-      // Maybe we should remove them, because they are in src/actions/friendsServices.ts
+
       handleLike: async (idPotentialFriend: string) => {
+        get().potentialFriends?.forEach((friend) => {
+          if (friend.id === idPotentialFriend) {
+            friend.likedByMe = true
+          }
+        })
+
         try {
           return await addLike(idPotentialFriend)
         } catch (error) {

--- a/src/zustand/friendsStore.ts
+++ b/src/zustand/friendsStore.ts
@@ -189,14 +189,17 @@ export const usePotentialFriendsStore = create<PotentialFriendsStore>()(
       },
 
       handleLike: async (idPotentialFriend: string) => {
-        get().potentialFriends?.forEach((friend) => {
-          if (friend.id === idPotentialFriend) {
+        try {
+          const result = await addLike(idPotentialFriend)
+          const friend = get().potentialFriends?.find((friend) => {
+            return friend.id === idPotentialFriend
+          })
+
+          if (friend) {
             friend.likedByMe = true
           }
-        })
 
-        try {
-          return await addLike(idPotentialFriend)
+          return result
         } catch (error) {
           console.error('Error adding like:', error)
           set({ error: handleError(error) })

--- a/src/zustand/friendsStore.ts
+++ b/src/zustand/friendsStore.ts
@@ -191,13 +191,14 @@ export const usePotentialFriendsStore = create<PotentialFriendsStore>()(
       handleLike: async (idPotentialFriend: string) => {
         try {
           const result = await addLike(idPotentialFriend)
-          const friend = get().potentialFriends?.find((friend) => {
-            return friend.id === idPotentialFriend
-          })
+          const friends = [...(get().potentialFriends ?? [])]
+          const friend = friends.find((f) => f.id === idPotentialFriend)
 
           if (friend) {
             friend.likedByMe = true
           }
+
+          set({ potentialFriends: friends })
 
           return result
         } catch (error) {


### PR DESCRIPTION
[Task link:]https://app.clickup.com/t/9012052932/869dxcq7c

**What has been done:**
- [x] Prevent redundant API requests for Swipe component on page change

**How to test:**
1. open page /swipes and switch between tabs (Messages and New Friends) 
2. The `api/profile/search` request is NOT triggered again on tab/page change if the data is already loaded (no redundant API requests).
3. liked user on "/near-me" page and that user will not be appear in "/swipe"

**Checklist:**
- [x] Local tests passed
- [x] No extra console logs left
- [ ] Code is formatted with Prettier
