### PR TITLE
feat:  implement  update friends after created chat

### DIFF
--- a/src/zustand/conversationsStore.ts
+++ b/src/zustand/conversationsStore.ts
@@ -16,6 +16,7 @@ import {
 } from 'firebase/firestore'
 import { useUserProfileStore } from './userProfileStore'
 import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
+import { useMatchesStore } from 'zustand/friendsStore'
 
 interface ConversationsState {
   conversations: Conversation[]
@@ -201,6 +202,7 @@ export const useConversationsStore = create<ConversationsState>()(
 
         // Set up the listener
         set({ loading: true, error: null })
+        let initialized = false
 
         const unsubscribe = onSnapshot(
           conversationsQuery,
@@ -213,6 +215,17 @@ export const useConversationsStore = create<ConversationsState>()(
                   data: doc.data(),
                 })),
               })
+
+              // Check if this is the first snapshot to fetch new friends
+              if (!initialized) {
+                initialized = true
+              } else {
+                querySnapshot.docChanges().forEach((change) => {
+                  if (change.type === 'added') {
+                    useMatchesStore.getState().fetchMatches()
+                  }
+                })
+              }
 
               // Get the userProfileStore instance
               const userProfileStore = useUserProfileStore.getState()


### PR DESCRIPTION
[Task link:]https://app.clickup.com/t/9012052932/869e7kpfy?utm_source=email-notifications&utm_type=1&utm_field=assignee_add

**What has been done:**
- [x] Update friends after the new chat chat created


**How to test:**
1. created a match between 2 users
2. click created chat button  
3. after chat created user you  created chat with should disappear from friends tabs /friends

**Checklist:**
- [x] Local tests passed
- [x] No extra console logs left
- [ ] Code is formatted with Prettier
