### PR TITLE
refactor: migrate matches logic from RTDB to Firestore

### DIFF
--- a/src/provider/AuthTokenAndStoreProvider.tsx
+++ b/src/provider/AuthTokenAndStoreProvider.tsx
@@ -131,7 +131,9 @@ const AuthTokenAndStoreProvider = ({
       handleMatchUpdate()
     })
 
-    return () => unsubscribe()
+    return () => {
+      unsubscribe()
+    }
   }, [profile?._id, handleMatchUpdate])
 
   return <>{children}</>

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -1,8 +1,6 @@
 import { initializeApp, getApps, getApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
 
-import { getDatabase } from 'firebase/database'
-
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
@@ -17,5 +15,3 @@ const firebaseConfig = {
 export const app = !getApps().length ? initializeApp(firebaseConfig) : getApp()
 
 export const db = getFirestore(app)
-
-export const rtdb = getDatabase(app)

--- a/src/services/matches.ts
+++ b/src/services/matches.ts
@@ -21,10 +21,12 @@ export function subscribeToMatches(
         return
       }
       snapshot.docChanges().forEach((change) => {
-        callback({
-          type: change.type,
-          userId,
-        } as MatchEvent)
+        if (change.type === 'added' || change.type === 'removed') {
+          callback({
+            type: change.type,
+            userId,
+          } as MatchEvent)
+        }
       })
     },
     (err) => {

--- a/src/services/matches.ts
+++ b/src/services/matches.ts
@@ -1,49 +1,34 @@
-import { ref, onChildAdded, onChildRemoved, get } from 'firebase/database'
-import { rtdb } from './firebase'
+import { db } from './firebase'
 import { MatchEvent } from 'types/Matches'
+import { collection, query, onSnapshot, where } from 'firebase/firestore'
 
 export function subscribeToMatches(
   userId: string,
   callback: (data: MatchEvent) => void
 ) {
-  const matchesRef = ref(rtdb, `matches/${userId}`)
   let initialized = false
 
-  const existing = new Set<string>()
+  const q = query(
+    collection(db, 'matches'),
+    where('users', 'array-contains', userId)
+  )
 
-  const unsubscribeAdded = onChildAdded(matchesRef, async (snapshot) => {
-    const key = snapshot.key!
-
-    if (!initialized) {
-      existing.add(key)
-      return
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      if (!initialized) {
+        initialized = true
+        return
+      }
+      snapshot.docChanges().forEach((change) => {
+        callback({
+          type: change.type,
+          userId,
+        } as MatchEvent)
+      })
+    },
+    (err) => {
+      console.error(err)
     }
-
-    if (existing.has(key)) {
-      existing.delete(key)
-      return
-    }
-
-    callback({
-      type: 'added',
-      userId,
-    })
-  })
-
-  get(matchesRef).then((snapshot) => {
-    snapshot.forEach((child) => {
-      existing.add(child.key!)
-    })
-
-    initialized = true
-  })
-
-  const unsubscribeRemoved = onChildRemoved(matchesRef, () => {
-    callback({ type: 'removed', userId })
-  })
-
-  return () => {
-    unsubscribeAdded()
-    unsubscribeRemoved()
-  }
+  )
 }


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/9012052932/869e4v3m9)
**What has been done:**
- [x] migrate matches logic from RTDB to Firestore


**How to test:**
1. Sign in as User A and like User B.
2. Sign in as User B and like User A back to create a mutual match/friendship.
3. Verify that User A receives the real-time update and that the friends count is updated automatically on the screen displaying the number of friends, without requiring a page refresh.

**Checklist:**
- [x] Local tests passed
- [x] No extra console logs left
- [x] Code is formatted with Prettier
---
**Related PR / Refactored PR:** [link](https://github.com/WeFriiends/WeFriiendsFront/pull/153)