### PR TITLE
fix: add timeout 15 sec

### DIFF
--- a/src/actions/axiosInstance.ts
+++ b/src/actions/axiosInstance.ts
@@ -10,11 +10,6 @@ const axiosInstance = axios.create({
 })
 
 axiosInstance.interceptors.request.use((config) => {
-  // 🔧 ТЕСТ: реальный запрос, который висит 60с — чтобы сработал timeout
-  if (config.url?.includes('nearest')) {
-    return { ...config, baseURL: '', url: 'https://httpbin.org/delay/60' }
-  }
-
   const { token } = useAuthStore.getState()
   if (token) {
     config.headers.Authorization = `Bearer ${token}`

--- a/src/actions/axiosInstance.ts
+++ b/src/actions/axiosInstance.ts
@@ -3,12 +3,18 @@ import { useAuthStore } from 'zustand/store'
 
 const axiosInstance = axios.create({
   baseURL: `${process.env.REACT_APP_API_BASE_URL}/api/`,
+  timeout: 15000,
   headers: {
     'Content-Type': 'application/json',
   },
 })
 
 axiosInstance.interceptors.request.use((config) => {
+  // 🔧 ТЕСТ: реальный запрос, который висит 60с — чтобы сработал timeout
+  if (config.url?.includes('nearest')) {
+    return { ...config, baseURL: '', url: 'https://httpbin.org/delay/60' }
+  }
+
   const { token } = useAuthStore.getState()
   if (token) {
     config.headers.Authorization = `Bearer ${token}`


### PR DESCRIPTION
Task link: n/a
This PR fixes the "infinite loader" case where the backend accepts a request but never responds (deploy/restart, slow DB, dead mobile connection): axios now aborts after 15s with `ECONNABORTED` instead of hanging forever.  
Aborted requests flow into the existing error handling — full-screen error via `DataStateWrapper` for reads, snackbar for mutations — so the user gets a visible error + retry instead of a stuck screen

**What has been done:**
- [X] Added a 15s client-side request timeout to the shared axios instance (`src/actions/axiosInstance.ts`)

**How to test:**
1. Temporarily point a request at a hanging endpoint so it actually leaves the browser. In `axiosInstance.ts` add to the request interceptor:

```
if (config.url?.includes('nearest')) {
     return { ...config, baseURL: '', url: 'https://httpbin.org/delay/60' }
 }
```

2. Open the `Near Me` page. The request goes out and hangs (visible as (pending) in the Network tab).
3. Confirm that after ~15s the infinite loader is replaced by a "Network Error" screen (before this fix it would spin forever).
4. Remove the temporary interceptor snippet before merging.

**Checklist:**
- [ ] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier
