### PR TITLE
feat: add new message indicators

### DIFF
--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -23,7 +23,7 @@ export function ChatContainer({ chat }: ChatContainerProps) {
   // Driven by the conversation itself, so it works regardless of which
   // messages are currently loaded in the paginated window.
   useEffect(() => {
-    if (Number(chat.messageCount) > 0) {
+    if (chat.messageCount > 0) {
       useConversationsStore
         .getState()
         .markConversationAsRead(chat.conversationRef)

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react'
 import { Box } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { MessagesBox } from './MessagesBox'
 import { ChatHeader } from './ChatHeader'
 import { useChatStore } from '../../zustand/chatStore'
+import { useConversationsStore } from '../../zustand/conversationsStore'
 import { StartChatting } from './StartChatting'
 import { ChatInput } from './ChatInput'
 import { Conversation } from 'types/Conversation'
@@ -15,6 +17,18 @@ export function ChatContainer({ chat }: ChatContainerProps) {
   const { classes } = useStyles()
   const { currentChat, loading } = useChatStore()
   const chatData = currentChat || { chatId: '', participants: [], messages: [] }
+
+  // Reset the conversation-level unread indicator (envelope + header dot)
+  // whenever this chat is open and the last message came from the other user.
+  // Driven by the conversation itself, so it works regardless of which
+  // messages are currently loaded in the paginated window.
+  useEffect(() => {
+    if (Number(chat.messageCount) > 0) {
+      useConversationsStore
+        .getState()
+        .markConversationAsRead(chat.conversationRef)
+    }
+  }, [chat.messageCount, chat.conversationRef])
   return (
     <Box className={classes.container}>
       <ChatHeader chat={chat} />

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -3,10 +3,18 @@ import { BottomNavigation } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { NavigationLink } from './NavigationLink'
 import { navMenu } from '../../data/navMenu'
+import { useConversationsStore } from 'zustand/conversationsStore'
+import { APP_ROUTES } from 'routes/appRoutes'
 
 export function NavBar() {
   const location = useLocation()
   const { classes } = useStyles()
+  const hasUnreadMessages = useConversationsStore((state) =>
+    state.conversations.some(
+      (conversation) => Number(conversation.messageCount) > 0
+    )
+  )
+
   return (
     <BottomNavigation className={classes.list} component="nav">
       {navMenu.map(({ to, icon }) => (
@@ -15,6 +23,7 @@ export function NavBar() {
           to={to}
           icon={icon}
           isActive={location.pathname === to}
+          showBadge={to === `/${APP_ROUTES.messages}` && hasUnreadMessages}
         />
       ))}
     </BottomNavigation>

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -10,9 +10,7 @@ export function NavBar() {
   const location = useLocation()
   const { classes } = useStyles()
   const hasUnreadMessages = useConversationsStore((state) =>
-    state.conversations.some(
-      (conversation) => Number(conversation.messageCount) > 0
-    )
+    state.conversations.some((conversation) => conversation.messageCount > 0)
   )
 
   return (

--- a/src/components/navBar/NavigationLink.tsx
+++ b/src/components/navBar/NavigationLink.tsx
@@ -8,13 +8,27 @@ interface NavigationLink {
   to: string
   icon: FC<IconProps>
   isActive: boolean
+  showBadge?: boolean
 }
 
-export function NavigationLink({ to, icon: Icon, isActive }: NavigationLink) {
+export function NavigationLink({
+  to,
+  icon: Icon,
+  isActive,
+  showBadge = false,
+}: NavigationLink) {
   const { classes } = useStyles()
 
   const linkIcon = (
-    <Badge invisible>
+    <Badge
+      variant="dot"
+      invisible={!showBadge}
+      sx={{
+        '& .MuiBadge-badge': {
+          backgroundColor: theme.palette.primary.main,
+        },
+      }}
+    >
       <Icon
         color={
           isActive

--- a/src/components/tabsMessagesFriends/ConversationItem.tsx
+++ b/src/components/tabsMessagesFriends/ConversationItem.tsx
@@ -36,7 +36,7 @@ export function ConversationItem({ conversation }: ConversationItemProps) {
             {conversation.lastMessage}
           </Typography>
         </Box>
-        {Number(conversation.messageCount) > 0 && <UnreadMessageIndicator />}
+        {conversation.messageCount > 0 && <UnreadMessageIndicator />}
       </Box>
     </button>
   )

--- a/src/components/tabsMessagesFriends/ConversationItem.tsx
+++ b/src/components/tabsMessagesFriends/ConversationItem.tsx
@@ -36,7 +36,7 @@ export function ConversationItem({ conversation }: ConversationItemProps) {
             {conversation.lastMessage}
           </Typography>
         </Box>
-        {conversation.messageCount === '1' && <UnreadMessageIndicator />}
+        {Number(conversation.messageCount) > 0 && <UnreadMessageIndicator />}
       </Box>
     </button>
   )

--- a/src/helpers/isConversationUnread.ts
+++ b/src/helpers/isConversationUnread.ts
@@ -1,0 +1,7 @@
+import type { FirestoreConversation } from 'types/FirestoreConversation'
+
+export const isConversationUnread = (
+  data: FirestoreConversation,
+  currentUserId: string
+): boolean =>
+  data.lastMessageSeen === false && data.lastMessageSender !== currentUserId

--- a/src/types/Conversation.ts
+++ b/src/types/Conversation.ts
@@ -4,7 +4,7 @@ export interface Conversation {
   name: string
   age: string
   lastMessage: string
-  messageCount: string
+  messageCount: number
   conversationRef: string
   lastMessageSeen: boolean
 }

--- a/src/types/FirestoreConversation.ts
+++ b/src/types/FirestoreConversation.ts
@@ -1,0 +1,14 @@
+import type { Timestamp } from 'firebase/firestore'
+
+/**
+ * Shape of a document stored in the Firestore `conversations` collection
+ * (as returned by `doc.data()`), not the mapped UI `Conversation` type.
+ */
+export interface FirestoreConversation {
+  participants: string[]
+  lastMessage: string
+  lastMessageAt: Timestamp
+  createdAt: Timestamp
+  lastMessageSender?: string
+  lastMessageSeen?: boolean
+}

--- a/src/zustand/chatStore.ts
+++ b/src/zustand/chatStore.ts
@@ -473,6 +473,7 @@ export const useChatStore = create<ChatState>()(
             lastMessage: message.text,
             lastMessageAt: serverTimestamp(),
             lastMessageSeen: false,
+            lastMessageSender: message.senderId,
           })
 
           // We don't need to update the local state here

--- a/src/zustand/conversationsStore.ts
+++ b/src/zustand/conversationsStore.ts
@@ -13,10 +13,13 @@ import {
   setDoc,
   getDoc,
   serverTimestamp,
+  updateDoc,
 } from 'firebase/firestore'
 import { useUserProfileStore } from './userProfileStore'
 import { DEFAULT_PROFILE_PHOTO } from 'data/constants'
 import { useMatchesStore } from 'zustand/friendsStore'
+import type { FirestoreConversation } from 'types/FirestoreConversation'
+import { isConversationUnread } from 'helpers/isConversationUnread'
 
 interface ConversationsState {
   conversations: Conversation[]
@@ -29,6 +32,7 @@ interface ConversationsState {
   subscribeToConversations: (userId: string) => void
   unsubscribeFromConversations: () => void
   createConversation: (currentUserId: string, userId: string) => Promise<string>
+  markConversationAsRead: (conversationId: string) => Promise<void>
 }
 
 export const useConversationsStore = create<ConversationsState>()(
@@ -117,13 +121,21 @@ export const useConversationsStore = create<ConversationsState>()(
 
           // Process the results
           for (const doc of querySnapshot.docs) {
-            const conversationData = doc.data()
+            const conversationData = doc.data() as FirestoreConversation
             // console.log('Processing conversation document:', {id: doc.id, data: conversationData,})
 
             // Get the other participant's ID
             const otherParticipantId = conversationData.participants.find(
               (participantId: string) => participantId !== currentUserId
             )
+
+            if (!otherParticipantId) {
+              console.error(
+                `Conversation ${doc.id} has no other participant, skipping`,
+                conversationData.participants
+              )
+              continue
+            }
 
             // Fetch the user profile
             // console.log(`Fetching profile for user: ${otherParticipantId}`)
@@ -134,19 +146,16 @@ export const useConversationsStore = create<ConversationsState>()(
             // Create a UserLastMessage object with profile data if available
             const userMessage: Conversation = {
               id: otherParticipantId,
-              avatar:
-                profile?.photos?.[0] ||
-                conversationData.participantAvatar ||
-                DEFAULT_PROFILE_PHOTO,
-              name:
-                profile?.name || conversationData.participantName || `Friend`,
-              age:
-                profile?.age?.toString() ||
-                conversationData.participantAge ||
-                `--`,
+              avatar: profile?.photos?.[0] || DEFAULT_PROFILE_PHOTO,
+              name: profile?.name || `Friend`,
+              age: profile?.age?.toString() || `--`,
               lastMessage: conversationData.lastMessage || '',
-              messageCount:
-                conversationData.lastMessageSeen === false ? '1' : '0',
+              messageCount: isConversationUnread(
+                conversationData,
+                currentUserId
+              )
+                ? '1'
+                : '0',
               conversationRef: doc.id,
               lastMessageSeen:
                 conversationData.lastMessageSeen !== undefined
@@ -233,7 +242,7 @@ export const useConversationsStore = create<ConversationsState>()(
 
               // Process the results
               for (const doc of querySnapshot.docs) {
-                const conversationData = doc.data()
+                const conversationData = doc.data() as FirestoreConversation
                 // console.log('Processing conversation document:', {
                 //   id: doc.id,
                 //   data: conversationData,
@@ -244,6 +253,14 @@ export const useConversationsStore = create<ConversationsState>()(
                   (participantId: string) => participantId !== currentUserId
                 )
 
+                if (!otherParticipantId) {
+                  console.error(
+                    `Conversation ${doc.id} has no other participant, skipping`,
+                    conversationData.participants
+                  )
+                  continue
+                }
+
                 // Fetch the user profile
                 // console.log(`Fetching profile for user: ${otherParticipantId}`)
                 const profile = await userProfileStore.fetchUserProfile(
@@ -253,21 +270,16 @@ export const useConversationsStore = create<ConversationsState>()(
                 // Create a UserLastMessage object with profile data if available
                 const userMessage: Conversation = {
                   id: otherParticipantId,
-                  avatar:
-                    profile?.photos?.[0] ||
-                    conversationData.participantAvatar ||
-                    DEFAULT_PROFILE_PHOTO,
-                  name:
-                    profile?.name ||
-                    conversationData.participantName ||
-                    `Friend`,
-                  age:
-                    profile?.age?.toString() ||
-                    conversationData.participantAge ||
-                    `--`,
+                  avatar: profile?.photos?.[0] || DEFAULT_PROFILE_PHOTO,
+                  name: profile?.name || `Friend`,
+                  age: profile?.age?.toString() || `--`,
                   lastMessage: conversationData.lastMessage || '',
-                  messageCount:
-                    conversationData.lastMessageSeen === false ? '1' : '0',
+                  messageCount: isConversationUnread(
+                    conversationData,
+                    currentUserId
+                  )
+                    ? '1'
+                    : '0',
                   conversationRef: doc.id,
                   lastMessageSeen:
                     conversationData.lastMessageSeen !== undefined
@@ -372,6 +384,20 @@ export const useConversationsStore = create<ConversationsState>()(
             loading: false,
           })
           throw error
+        }
+      },
+
+      markConversationAsRead: async (conversationId: string) => {
+        if (!conversationId) {
+          return
+        }
+
+        try {
+          await updateDoc(doc(db, 'conversations', conversationId), {
+            lastMessageSeen: true,
+          })
+        } catch (error) {
+          console.error('Failed to mark conversation as read:', error)
         }
       },
     }),

--- a/src/zustand/conversationsStore.ts
+++ b/src/zustand/conversationsStore.ts
@@ -154,8 +154,8 @@ export const useConversationsStore = create<ConversationsState>()(
                 conversationData,
                 currentUserId
               )
-                ? '1'
-                : '0',
+                ? 1
+                : 0,
               conversationRef: doc.id,
               lastMessageSeen:
                 conversationData.lastMessageSeen !== undefined
@@ -274,12 +274,14 @@ export const useConversationsStore = create<ConversationsState>()(
                   name: profile?.name || `Friend`,
                   age: profile?.age?.toString() || `--`,
                   lastMessage: conversationData.lastMessage || '',
+                  // For MVP-1 Firestore doesn't yet store an unread count—we use 1/0 as a flag.
+                  // Replace with a real unreadCount when the backend starts returning it.
                   messageCount: isConversationUnread(
                     conversationData,
                     currentUserId
                   )
-                    ? '1'
-                    : '0',
+                    ? 1
+                    : 0,
                   conversationRef: doc.id,
                   lastMessageSeen:
                     conversationData.lastMessageSeen !== undefined


### PR DESCRIPTION
[Task link:](https://app.clickup.com/t/9012052932/869b010t3)

**What has been done:**
- [X] Added an unread envelope indicator on chat list items for conversations with unread incoming messages (own sent messages no longer trigger it)
- [X] Added an unread dot on the Messages icon in the header when any conversation has unread messages
- [X] Indicators reset automatically when the conversation is opened, and update in real time (new messages while online) and on login (messages received while away)

**How to test:**
1. Log in as user A, send a message to user B → user B sees the envelope on user A chat row and the dot on the Messages icon; user A sees no indicator on their own side.
2. As user B, open the chat with A → the envelope and the header dot disappear; with multiple unread chats, the dot stays until all are read.
3. Log B out, send a message from A, log B back in → indicators appear immediately after login, reflecting messages missed while away.

**Checklist:**
- [ ] Local tests passed
- [X] No extra console logs left
- [X] Code is formatted with Prettier

**Screenshots**:

| **new unread messages**  | **after reading** | 
|:---------------------:|:-----------------------:|
| <a href="https://github.com/user-attachments/assets/94442612-fc53-4198-a1a2-56113a144c1e"><img src="https://github.com/user-attachments/assets/94442612-fc53-4198-a1a2-56113a144c1e" width="250"></a> | <a href="https://github.com/user-attachments/assets/b4268dc9-bdf7-45d8-83a6-958102d37fed"><img src="https://github.com/user-attachments/assets/b4268dc9-bdf7-45d8-83a6-958102d37fed" width="250"></a> | 